### PR TITLE
Implement dark mode toggle for dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,14 @@
     :root {
       --blue: #6366f1;
       --blue-light: #818cf8;
+      /* Light theme colors */
+      --bg-dark: #ffffff;
+      --text-dark: #1e293b;
+      --card-bg: #f9fafb;
+      --card-bg-light: #e5e7eb;
+    }
+    /* Dark mode variables */
+    body.dark-mode {
       --bg-dark: #1e293b;
       --text-dark: #e0e7ff;
       --card-bg: #111827;
@@ -487,10 +495,17 @@
     setInterval(updateTime, 1000);
     updateTime();
 
-    // Dark mode toggle
+    // Dark mode toggle with persistence
     const themeToggleBtn = document.getElementById('theme-toggle');
+    const saved = localStorage.getItem('bbs-theme');
+    if (saved === 'dark') {
+      document.body.classList.add('dark-mode');
+      themeToggleBtn.innerHTML = '<i class="ri-sun-line"></i>';
+    }
     themeToggleBtn.addEventListener('click', () => {
-      document.body.classList.toggle('dark-mode');
+      const dark = document.body.classList.toggle('dark-mode');
+      themeToggleBtn.innerHTML = dark ? '<i class="ri-sun-line"></i>' : '<i class="ri-moon-clear-line"></i>';
+      localStorage.setItem('bbs-theme', dark ? 'dark' : 'light');
     });
 
     // Global search setup


### PR DESCRIPTION
## Summary
- make index.html default to a light palette
- add dark mode variables that activate via `.dark-mode`
- persist user's theme choice in localStorage

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684442b725a48325a952a4f8e66fb28a