### PR TITLE
Add color theme palette and glow effect

### DIFF
--- a/customers.html
+++ b/customers.html
@@ -6,6 +6,7 @@
   <title>Customers | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     table {
       width: 100%;
@@ -105,11 +106,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/dashboard.html
+++ b/dashboard.html
@@ -6,6 +6,7 @@
   <title>Dashboard | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link href="theme.css" rel="stylesheet" />
   <style>
     :root {
       --blue: #6366f1;
@@ -422,11 +423,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Dashboard | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link href="theme.css" rel="stylesheet" />
   <style>
     :root {
       --blue: #6366f1;
@@ -428,11 +429,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/login.html
+++ b/login.html
@@ -6,6 +6,7 @@
   <title>Login | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
 </head>
 <body>
   <div class="main-content login-main">

--- a/products-list.html
+++ b/products-list.html
@@ -6,6 +6,7 @@
   <title>Products List | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     table {
       width: 100%;
@@ -63,11 +64,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/products.html
+++ b/products.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Products | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
+  <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     /* Paste the same CSS styles.css content here or link styles.css externally */
   </style>
@@ -50,11 +52,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/purchase.html
+++ b/purchase.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Purchase | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
+  <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     /* Paste your global styles.css content here or link externally */
   </style>
@@ -50,11 +52,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/register.html
+++ b/register.html
@@ -6,6 +6,7 @@
   <title>Register | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
 </head>
 <body>
   <div class="main-content login-main">

--- a/reports.html
+++ b/reports.html
@@ -6,6 +6,7 @@
   <title>Reports | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     .reports-section {
       margin-bottom: 2rem;
@@ -89,11 +90,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/sales.html
+++ b/sales.html
@@ -6,6 +6,7 @@
   <title>Sales Entry | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
 </head>
 <body>
   <div class="container">
@@ -30,11 +31,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/scripts.js
+++ b/scripts.js
@@ -1,10 +1,11 @@
 // scripts.js
 
-// Theme color pills logic
-function setColorTheme(theme) {
-  document.documentElement.setAttribute('data-theme', theme);
-  localStorage.setItem('bbs-color-theme', theme);
-  document.querySelectorAll('.pill').forEach(p => p.classList.toggle('active', p.getAttribute('data-theme') === theme));
+const colorThemes=["blue","black","orange","sky"];
+function setColorTheme(theme){
+  if(!colorThemes.includes(theme)) theme="blue";
+  document.documentElement.setAttribute("data-theme",theme);
+  localStorage.setItem("bbs-color-theme",theme);
+  document.querySelectorAll(".pill").forEach(p=>p.classList.toggle("active",p.getAttribute("data-theme")===theme));
 }
 
 (() => {

--- a/settings.html
+++ b/settings.html
@@ -6,6 +6,7 @@
   <title>Settings | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     .tabs {
       display: flex;
@@ -104,11 +105,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/suppliers.html
+++ b/suppliers.html
@@ -6,6 +6,7 @@
   <title>Suppliers | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     table {
       width: 100%;
@@ -105,11 +106,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">

--- a/theme.css
+++ b/theme.css
@@ -1,0 +1,30 @@
+:root {
+  --blue: #3b82f6;
+  --blue-light: #60a5fa;
+  --shadow-color: rgba(0,0,0,0.5);
+}
+body, form, form label, form input, form select, form textarea, form button {
+  text-shadow: 0.5px 1px var(--shadow-color);
+}
+
+[data-theme="blue"] {
+  --blue: #3b82f6;
+  --blue-light: #60a5fa;
+}
+[data-theme="black"] {
+  --blue: #000000;
+  --blue-light: #4b5563;
+}
+[data-theme="orange"] {
+  --blue: #ff6b00;
+  --blue-light: #ff9e42;
+}
+[data-theme="sky"] {
+  --blue: #0ea5e9;
+  --blue-light: #38bdf8;
+}
+
+.pill[data-theme="blue"] { background: #3b82f6; }
+.pill[data-theme="black"] { background: #000; }
+.pill[data-theme="orange"] { background: #ff6b00; }
+.pill[data-theme="sky"] { background: #0ea5e9; }

--- a/users.html
+++ b/users.html
@@ -6,6 +6,7 @@
   <title>User Management | Business Billing System</title>
   <link href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css" rel="stylesheet" />
   <link href="styles.css" rel="stylesheet" />
+  <link href="theme.css" rel="stylesheet" />
   <style>
     .user-form {
       max-width: 600px;
@@ -105,11 +106,9 @@
       </nav>
       <div class="theme-pills" id="theme-pills">
         <span class="pill" data-theme="blue" title="Blue"></span>
-        <span class="pill" data-theme="lavender" title="Lavender"></span>
-        <span class="pill" data-theme="mint" title="Mint"></span>
-        <span class="pill" data-theme="peach" title="Peach"></span>
-        <span class="pill" data-theme="coral" title="Coral"></span>
-        <span class="pill" data-theme="lemon" title="Lemon"></span>
+        <span class="pill" data-theme="black" title="Black"></span>
+        <span class="pill" data-theme="orange" title="Orange"></span>
+        <span class="pill" data-theme="sky" title="Sky Blue"></span>
       </div>
     </aside>
     <div class="main-content">


### PR DESCRIPTION
## Summary
- add new `theme.css` with vibrant color palettes and text shadows
- hook up the theme CSS on all pages
- simplify palette options to blue, black, orange and sky
- validate selected color theme in `scripts.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68444538d9b8832590c1d0e89aa39385